### PR TITLE
Add debian package 'file' to build dependencies to resolve "CPack: Create package" error.

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -53,7 +53,7 @@ gdb ./build/cherrytree
 ## Building Cherrytree on Debian (+Ubuntu/Linux Mint)
 Install dependencies:
 ```sh
-sudo apt install build-essential cmake ninja-build libgtkmm-3.0-dev libgtksourceviewmm-3.0-dev libxml++2.6-dev libsqlite3-dev gettext libgspell-1-dev libcurl4-openssl-dev libuchardet-dev libfribidi-dev libvte-2.91-dev libfmt-dev libspdlog-dev
+sudo apt install build-essential cmake ninja-build libgtkmm-3.0-dev libgtksourceviewmm-3.0-dev libxml++2.6-dev libsqlite3-dev gettext libgspell-1-dev libcurl4-openssl-dev libuchardet-dev libfribidi-dev libvte-2.91-dev libfmt-dev libspdlog-dev file
 sudo apt install texlive-latex-base dvipng # optional for LatexBoxes support
 ```
 Note: On Debian10 / Ubuntu 18.04 libfmt-dev and libspdlog-dev are not used since too old; bundled source code is built instead


### PR DESCRIPTION
Add debian package 'file' to build dependencies to resolve "CPack: Create package" error.